### PR TITLE
RUN-5459: Enable CLI reporting on Mac & Linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var configBuilder = require('openfin-config-builder'),
     fs = require('fs'),
     request = require('request'),
     parseURLOrFile = require('./parse-url-or-file'),
+    reportUsage = require('./report-usage'),
     meow;
 
 function main(cli) {
@@ -26,7 +27,7 @@ function main(cli) {
 
     try {
         writeToConfig(name, parsedUrl, config, devtools_port, runtime_version, function (configObj) {
-            if (launch) launchOpenfin(config);
+            if (launch) launchOpenfin(config, configObj);
         });
     } catch (err) {
         onError('Failed:', err);
@@ -53,7 +54,8 @@ function onError(message, err) {
 }
 
 //will launch download the rvm and launch openfin
-async function launchOpenfin(config) {
+async function launchOpenfin(config, configObj) {
+    if (process.platform === 'darwin') reportUsage('START', config, configObj);
     try {
         const manifestUrl = isURL(config) ? config : path.resolve(config);
         const port = await launch({ manifestUrl, installerUI: true });
@@ -65,6 +67,7 @@ async function launchOpenfin(config) {
 
         fin.once('disconnected', process.exit);
     } catch (err) {
+        if (process.platform === 'darwin') reportUsage(err.toString(), config, configObj);
         console.error(err);
     }
 }

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function onError(message, err) {
 
 //will launch download the rvm and launch openfin
 async function launchOpenfin(config, configObj) {
-    if (process.platform === 'darwin') reportUsage('START', config, configObj);
+    reportUsage('START', config, configObj);
     try {
         const manifestUrl = isURL(config) ? config : path.resolve(config);
         const port = await launch({ manifestUrl, installerUI: true });
@@ -67,7 +67,7 @@ async function launchOpenfin(config, configObj) {
 
         fin.once('disconnected', process.exit);
     } catch (err) {
-        if (process.platform === 'darwin') reportUsage(err.toString(), config, configObj);
+        reportUsage(err.toString(), config, configObj);
         console.error(err);
     }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "files": [
         "index.js",
         "cli.js",
-        "parse-url-or-file.js"
+        "parse-url-or-file.js",
+        "report-usage.js"
     ],
     "keywords": [
         "openfin-cli"
@@ -37,6 +38,7 @@
         "grunt-mocha-cli": "^4.0.0",
         "jshint-stylish": "^1.0.0",
         "load-grunt-tasks": "^4.0.0",
+        "node-machine-id": "^1.1.10",
         "time-grunt": "^1.0.0"
     },
     "scripts": {

--- a/report-usage.js
+++ b/report-usage.js
@@ -1,0 +1,32 @@
+'use strict';
+var https = require('https'),
+    mid = require('node-machine-id'),
+    os = require('os'),
+    querystring = require('querystring');
+
+module.exports = function(status, config, configObj) {
+    var reportURL = 'https://install.openfin.co/installer-usage?';
+    var queryObj = {
+        appName: configObj.startup_app.name || 'TMP',
+        appLocation: __dirname,
+        version: configObj.runtime.version || 'undefined',
+        machineId: mid.machineIdSync({original: true}).toUpperCase(),
+        manifestUrl: config,
+        platform: os.platform().concat('-', os.release()),
+        licenseKey: configObj.licenseKey || "contract_identifier",
+        launchMethod: 'openfin-cli',
+        launchStatus : status || 'SUCCESS'
+    }
+
+    https.get(reportURL.concat(querystring.stringify(queryObj)), (resp) => {
+        let data = '';
+        resp.on('data', (chunk) => {
+            data += chunk;
+        });
+        resp.on('end', () => {
+            console.log('report usage data: ', data);
+        });
+    }).on("error", (err) => {
+        console.log("report usage data error: " + err.message);
+    });
+};

--- a/report-usage.js
+++ b/report-usage.js
@@ -5,6 +5,9 @@ var https = require('https'),
     querystring = require('querystring');
 
 module.exports = function(status, config, configObj) {
+    if (process.platform === 'win32')
+        return;
+
     var reportURL = 'https://install.openfin.co/installer-usage?';
     var queryObj = {
         appName: configObj.startup_app.name || 'TMP',


### PR DESCRIPTION
Add configObj as argument to help reporting client's usage data on OSX and Linux